### PR TITLE
- adding support for pricing

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 32
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,11 @@
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:seatsio/seatsio.dart';
 
-const String YourWorkspaceKey = " ";
-const String YourEventKey = " ";
+const String YourWorkspaceKey = "";
+const String YourEventKey = "";
 
 void main() {
   runApp(MyApp());
@@ -42,6 +45,9 @@ class _MyHomePageState extends State<MyHomePage> {
     _chartConfig = SeatingChartConfig.init().rebuild((b) => b
       ..workspaceKey = YourWorkspaceKey
       ..eventKey = YourEventKey
+      ..enableHoldSucceededCallback = true
+      ..enableHoldFailedCallback = true
+      ..enableObjectClickedCallback = false // Set this to false if you want to have the objectToolTip to be shown
       ..session = "start");
   }
 
@@ -97,6 +103,10 @@ class _MyHomePageState extends State<MyHomePage> {
         print(
             "[Seatsio]->[example]-> onObjectDeselected, label: ${object.label}");
         _deselectSeat(object);
+      },
+      onHoldSucceeded: (objects, ticketTypes) {
+        print(
+            "[Seatsio]->[example]-> onObjectSelected, objects: $objects | ticket types: $ticketTypes");
       },
     );
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   # seatsio: ^0.1.1
   seatsio:
     path: ../
+  built_collection: ^5.1.1
+
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/models/pricing_for_category.dart
+++ b/lib/src/models/pricing_for_category.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+import 'package:json_annotation/json_annotation.dart';
 
 part 'pricing_for_category.g.dart';
 
@@ -13,9 +14,12 @@ abstract class PricingForCategory
   factory PricingForCategory([updates(PricingForCategoryBuilder b)]) =
       _$PricingForCategory;
 
-  String get category;
+  int? get categoryKey;
 
-  double get price;
+  @JsonKey()
+  String? get category;
+
+  num? get price;
 
   BuiltList<TicketTypePricing>? get ticketTypes;
 
@@ -33,6 +37,7 @@ abstract class PricingForCategory
     }
     // todo(sjq):当前pricing数据为空，以下代码待验证
     return PricingForCategory((b) => b
+      ..categoryKey = data["categoryKey"]
       ..category = data["category"]
       ..price = data["price"]
       ..ticketTypes =
@@ -41,6 +46,12 @@ abstract class PricingForCategory
 
   static Serializer<PricingForCategory> get serializer =>
       _$pricingForCategorySerializer;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'category': categoryKey ?? category,
+    'price': price
+  };
+
 }
 
 abstract class TicketTypePricing
@@ -52,7 +63,7 @@ abstract class TicketTypePricing
 
   String? get ticketType;
 
-  double? get price;
+  num? get price;
 
   String? get label;
 
@@ -66,8 +77,8 @@ abstract class TicketTypePricing
     return null;
   }
 
-  static BuiltList<TicketTypePricing>? arrayFromJson(String jsonString) {
-    final data = json.decode(jsonString);
+  static BuiltList<TicketTypePricing>? arrayFromJson(String? jsonString) {
+    final data = jsonString != null ? json.decode(jsonString!) : null;
     if (data != null && data is List) {
       final List<TicketTypePricing> objects = [];
       data.forEach((e) {

--- a/lib/src/models/pricing_for_category.g.dart
+++ b/lib/src/models/pricing_for_category.g.dart
@@ -22,15 +22,27 @@ class _$PricingForCategorySerializer
   Iterable<Object?> serialize(
       Serializers serializers, PricingForCategory object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'category',
-      serializers.serialize(object.category,
-          specifiedType: const FullType(String)),
-      'price',
-      serializers.serialize(object.price,
-          specifiedType: const FullType(double)),
-    ];
+    final result = <Object?>[];
     Object? value;
+    value = object.categoryKey;
+    if (value != null) {
+      result
+        ..add('categoryKey')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.category;
+    if (value != null) {
+      result
+        ..add('category')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.price;
+    if (value != null) {
+      result
+        ..add('price')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
+    }
     value = object.ticketTypes;
     if (value != null) {
       result
@@ -50,17 +62,21 @@ class _$PricingForCategorySerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'categoryKey':
+          result.categoryKey = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
         case 'category':
           result.category = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'price':
           result.price = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(num)) as num?;
           break;
         case 'ticketTypes':
           result.ticketTypes.replace(serializers.deserialize(value,
@@ -98,8 +114,7 @@ class _$TicketTypePricingSerializer
     if (value != null) {
       result
         ..add('price')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(double)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
     }
     value = object.label;
     if (value != null) {
@@ -119,7 +134,7 @@ class _$TicketTypePricingSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -129,7 +144,7 @@ class _$TicketTypePricingSerializer
           break;
         case 'price':
           result.price = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double?;
+              specifiedType: const FullType(num)) as num?;
           break;
         case 'label':
           result.label = serializers.deserialize(value,
@@ -144,23 +159,21 @@ class _$TicketTypePricingSerializer
 
 class _$PricingForCategory extends PricingForCategory {
   @override
-  final String category;
+  final int? categoryKey;
   @override
-  final double price;
+  final String? category;
+  @override
+  final num? price;
   @override
   final BuiltList<TicketTypePricing>? ticketTypes;
 
   factory _$PricingForCategory(
           [void Function(PricingForCategoryBuilder)? updates]) =>
-      (new PricingForCategoryBuilder()..update(updates)).build();
+      (new PricingForCategoryBuilder()..update(updates))._build();
 
   _$PricingForCategory._(
-      {required this.category, required this.price, this.ticketTypes})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        category, 'PricingForCategory', 'category');
-    BuiltValueNullFieldError.checkNotNull(price, 'PricingForCategory', 'price');
-  }
+      {this.categoryKey, this.category, this.price, this.ticketTypes})
+      : super._();
 
   @override
   PricingForCategory rebuild(
@@ -175,6 +188,7 @@ class _$PricingForCategory extends PricingForCategory {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is PricingForCategory &&
+        categoryKey == other.categoryKey &&
         category == other.category &&
         price == other.price &&
         ticketTypes == other.ticketTypes;
@@ -183,12 +197,15 @@ class _$PricingForCategory extends PricingForCategory {
   @override
   int get hashCode {
     return $jf($jc(
-        $jc($jc(0, category.hashCode), price.hashCode), ticketTypes.hashCode));
+        $jc($jc($jc(0, categoryKey.hashCode), category.hashCode),
+            price.hashCode),
+        ticketTypes.hashCode));
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('PricingForCategory')
+    return (newBuiltValueToStringHelper(r'PricingForCategory')
+          ..add('categoryKey', categoryKey)
           ..add('category', category)
           ..add('price', price)
           ..add('ticketTypes', ticketTypes))
@@ -200,13 +217,17 @@ class PricingForCategoryBuilder
     implements Builder<PricingForCategory, PricingForCategoryBuilder> {
   _$PricingForCategory? _$v;
 
+  int? _categoryKey;
+  int? get categoryKey => _$this._categoryKey;
+  set categoryKey(int? categoryKey) => _$this._categoryKey = categoryKey;
+
   String? _category;
   String? get category => _$this._category;
   set category(String? category) => _$this._category = category;
 
-  double? _price;
-  double? get price => _$this._price;
-  set price(double? price) => _$this._price = price;
+  num? _price;
+  num? get price => _$this._price;
+  set price(num? price) => _$this._price = price;
 
   ListBuilder<TicketTypePricing>? _ticketTypes;
   ListBuilder<TicketTypePricing> get ticketTypes =>
@@ -219,6 +240,7 @@ class PricingForCategoryBuilder
   PricingForCategoryBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _categoryKey = $v.categoryKey;
       _category = $v.category;
       _price = $v.price;
       _ticketTypes = $v.ticketTypes?.toBuilder();
@@ -239,15 +261,16 @@ class PricingForCategoryBuilder
   }
 
   @override
-  _$PricingForCategory build() {
+  PricingForCategory build() => _build();
+
+  _$PricingForCategory _build() {
     _$PricingForCategory _$result;
     try {
       _$result = _$v ??
           new _$PricingForCategory._(
-              category: BuiltValueNullFieldError.checkNotNull(
-                  category, 'PricingForCategory', 'category'),
-              price: BuiltValueNullFieldError.checkNotNull(
-                  price, 'PricingForCategory', 'price'),
+              categoryKey: categoryKey,
+              category: category,
+              price: price,
               ticketTypes: _ticketTypes?.build());
     } catch (_) {
       late String _$failedField;
@@ -256,7 +279,7 @@ class PricingForCategoryBuilder
         _ticketTypes?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'PricingForCategory', _$failedField, e.toString());
+            r'PricingForCategory', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -269,13 +292,13 @@ class _$TicketTypePricing extends TicketTypePricing {
   @override
   final String? ticketType;
   @override
-  final double? price;
+  final num? price;
   @override
   final String? label;
 
   factory _$TicketTypePricing(
           [void Function(TicketTypePricingBuilder)? updates]) =>
-      (new TicketTypePricingBuilder()..update(updates)).build();
+      (new TicketTypePricingBuilder()..update(updates))._build();
 
   _$TicketTypePricing._({this.ticketType, this.price, this.label}) : super._();
 
@@ -304,7 +327,7 @@ class _$TicketTypePricing extends TicketTypePricing {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('TicketTypePricing')
+    return (newBuiltValueToStringHelper(r'TicketTypePricing')
           ..add('ticketType', ticketType)
           ..add('price', price)
           ..add('label', label))
@@ -320,9 +343,9 @@ class TicketTypePricingBuilder
   String? get ticketType => _$this._ticketType;
   set ticketType(String? ticketType) => _$this._ticketType = ticketType;
 
-  double? _price;
-  double? get price => _$this._price;
-  set price(double? price) => _$this._price = price;
+  num? _price;
+  num? get price => _$this._price;
+  set price(num? price) => _$this._price = price;
 
   String? _label;
   String? get label => _$this._label;
@@ -353,7 +376,9 @@ class TicketTypePricingBuilder
   }
 
   @override
-  _$TicketTypePricing build() {
+  TicketTypePricing build() => _build();
+
+  _$TicketTypePricing _build() {
     final _$result = _$v ??
         new _$TicketTypePricing._(
             ticketType: ticketType, price: price, label: label);
@@ -362,4 +387,4 @@ class TicketTypePricingBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seating_chart_config.dart
+++ b/lib/src/models/seating_chart_config.dart
@@ -273,6 +273,10 @@ abstract class SeatingChartConfig
       "showSectionContents": showSectionContents ?? "auto",
     };
 
+    if (pricing != null) {
+      configMap["pricing"] = pricing?.toList();
+    }
+
     if (loading != null) {
       configMap["loading"] = loading;
     }

--- a/lib/src/models/seating_chart_config.g.dart
+++ b/lib/src/models/seating_chart_config.g.dart
@@ -392,17 +392,17 @@ class _$SeatingChartConfigSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'publicKey':
           result.workspaceKey = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'event':
           result.eventKey = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'chart':
           result.chart = serializers.deserialize(value,
@@ -531,7 +531,7 @@ class _$SeatingChartConfigSerializer
           break;
         case 'showLoadingAnimation':
           result.showLoadingAnimation = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'ticketListings':
           result.ticketListings = serializers.deserialize(value,
@@ -592,59 +592,59 @@ class _$SeatingChartConfigSerializer
           break;
         case 'enableChartRenderedCallback':
           result.enableChartRenderedCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableChartRenderingFailedCallback':
           result.enableChartRenderingFailedCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableObjectClickedCallback':
           result.enableObjectClickedCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableObjectSelectedCallback':
           result.enableObjectSelectedCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableObjectDeselectedCallback':
           result.enableObjectDeselectedCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableSelectionValidCallback':
           result.enableSelectionValidCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableSelectionInvalidCallback':
           result.enableSelectionInvalidCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableBestAvailableSelectedCallback':
           result.enableBestAvailableSelectedCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableBestAvailableSelectionFailedCallback':
           result.enableBestAvailableSelectionFailedCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableHoldSucceededCallback':
           result.enableHoldSucceededCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableHoldFailedCallback':
           result.enableHoldFailedCallback = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableReleaseHoldSucceededCallback':
           result.enableReleaseHoldSucceededCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableReleaseHoldFailedCallback':
           result.enableReleaseHoldFailedCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
         case 'enableSelectedObjectBookedCallback':
           result.enableSelectedObjectBookedCallback = serializers
-              .deserialize(value, specifiedType: const FullType(bool)) as bool;
+              .deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -685,21 +685,21 @@ class _$SelectedObjectSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'ticketType':
           result.ticketType = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'amount':
           result.amount = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'label':
           result.label = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -755,41 +755,41 @@ class _$ObjectTooltipSerializer implements StructuredSerializer<ObjectTooltip> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'showActionHint':
           result.showActionHint = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'showAvailability':
           result.showAvailability = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'showCategory':
           result.showCategory = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'showLabel':
           result.showLabel = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'showPricing':
           result.showPricing = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'showUnavailableNotice':
           result.showUnavailableNotice = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'stylizedLabel':
           result.stylizedLabel = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'confirmSelectionOnMobile':
           result.confirmSelectionOnMobile = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -828,17 +828,17 @@ class _$LegendForCategorySerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'hideNonSelectableCategories':
           result.hideNonSelectableCategories = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'hidePricing':
           result.hidePricing = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -882,13 +882,13 @@ class _$BestAvailableSerializer implements StructuredSerializer<BestAvailable> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'number':
           result.number = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'category':
           result.category.replace(serializers.deserialize(value,
@@ -903,7 +903,7 @@ class _$BestAvailableSerializer implements StructuredSerializer<BestAvailable> {
           break;
         case 'clearSelection':
           result.clearSelection = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -939,13 +939,13 @@ class _$SelectionValidatorSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'type':
           result.type = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -986,21 +986,21 @@ class _$TicketListingSerializer implements StructuredSerializer<TicketListing> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'section':
           result.section = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'quantity':
           result.quantity = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'price':
           result.price = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
       }
     }
@@ -1129,7 +1129,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
 
   factory _$SeatingChartConfig(
           [void Function(SeatingChartConfigBuilder)? updates]) =>
-      (new SeatingChartConfigBuilder()..update(updates)).build();
+      (new SeatingChartConfigBuilder()..update(updates))._build();
 
   _$SeatingChartConfig._(
       {required this.workspaceKey,
@@ -1192,41 +1192,41 @@ class _$SeatingChartConfig extends SeatingChartConfig {
       required this.enableSelectedObjectBookedCallback})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        workspaceKey, 'SeatingChartConfig', 'workspaceKey');
+        workspaceKey, r'SeatingChartConfig', 'workspaceKey');
     BuiltValueNullFieldError.checkNotNull(
-        eventKey, 'SeatingChartConfig', 'eventKey');
+        eventKey, r'SeatingChartConfig', 'eventKey');
     BuiltValueNullFieldError.checkNotNull(
-        showLoadingAnimation, 'SeatingChartConfig', 'showLoadingAnimation');
+        showLoadingAnimation, r'SeatingChartConfig', 'showLoadingAnimation');
     BuiltValueNullFieldError.checkNotNull(enableChartRenderedCallback,
-        'SeatingChartConfig', 'enableChartRenderedCallback');
+        r'SeatingChartConfig', 'enableChartRenderedCallback');
     BuiltValueNullFieldError.checkNotNull(enableChartRenderingFailedCallback,
-        'SeatingChartConfig', 'enableChartRenderingFailedCallback');
+        r'SeatingChartConfig', 'enableChartRenderingFailedCallback');
     BuiltValueNullFieldError.checkNotNull(enableObjectClickedCallback,
-        'SeatingChartConfig', 'enableObjectClickedCallback');
+        r'SeatingChartConfig', 'enableObjectClickedCallback');
     BuiltValueNullFieldError.checkNotNull(enableObjectSelectedCallback,
-        'SeatingChartConfig', 'enableObjectSelectedCallback');
+        r'SeatingChartConfig', 'enableObjectSelectedCallback');
     BuiltValueNullFieldError.checkNotNull(enableObjectDeselectedCallback,
-        'SeatingChartConfig', 'enableObjectDeselectedCallback');
+        r'SeatingChartConfig', 'enableObjectDeselectedCallback');
     BuiltValueNullFieldError.checkNotNull(enableSelectionValidCallback,
-        'SeatingChartConfig', 'enableSelectionValidCallback');
+        r'SeatingChartConfig', 'enableSelectionValidCallback');
     BuiltValueNullFieldError.checkNotNull(enableSelectionInvalidCallback,
-        'SeatingChartConfig', 'enableSelectionInvalidCallback');
+        r'SeatingChartConfig', 'enableSelectionInvalidCallback');
     BuiltValueNullFieldError.checkNotNull(enableBestAvailableSelectedCallback,
-        'SeatingChartConfig', 'enableBestAvailableSelectedCallback');
+        r'SeatingChartConfig', 'enableBestAvailableSelectedCallback');
     BuiltValueNullFieldError.checkNotNull(
         enableBestAvailableSelectionFailedCallback,
-        'SeatingChartConfig',
+        r'SeatingChartConfig',
         'enableBestAvailableSelectionFailedCallback');
     BuiltValueNullFieldError.checkNotNull(enableHoldSucceededCallback,
-        'SeatingChartConfig', 'enableHoldSucceededCallback');
+        r'SeatingChartConfig', 'enableHoldSucceededCallback');
     BuiltValueNullFieldError.checkNotNull(enableHoldFailedCallback,
-        'SeatingChartConfig', 'enableHoldFailedCallback');
+        r'SeatingChartConfig', 'enableHoldFailedCallback');
     BuiltValueNullFieldError.checkNotNull(enableReleaseHoldSucceededCallback,
-        'SeatingChartConfig', 'enableReleaseHoldSucceededCallback');
+        r'SeatingChartConfig', 'enableReleaseHoldSucceededCallback');
     BuiltValueNullFieldError.checkNotNull(enableReleaseHoldFailedCallback,
-        'SeatingChartConfig', 'enableReleaseHoldFailedCallback');
+        r'SeatingChartConfig', 'enableReleaseHoldFailedCallback');
     BuiltValueNullFieldError.checkNotNull(enableSelectedObjectBookedCallback,
-        'SeatingChartConfig', 'enableSelectedObjectBookedCallback');
+        r'SeatingChartConfig', 'enableSelectedObjectBookedCallback');
   }
 
   @override
@@ -1356,7 +1356,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatingChartConfig')
+    return (newBuiltValueToStringHelper(r'SeatingChartConfig')
           ..add('workspaceKey', workspaceKey)
           ..add('eventKey', eventKey)
           ..add('chart', chart)
@@ -1824,15 +1824,17 @@ class SeatingChartConfigBuilder
   }
 
   @override
-  _$SeatingChartConfig build() {
+  SeatingChartConfig build() => _build();
+
+  _$SeatingChartConfig _build() {
     _$SeatingChartConfig _$result;
     try {
       _$result = _$v ??
           new _$SeatingChartConfig._(
               workspaceKey: BuiltValueNullFieldError.checkNotNull(
-                  workspaceKey, 'SeatingChartConfig', 'workspaceKey'),
+                  workspaceKey, r'SeatingChartConfig', 'workspaceKey'),
               eventKey: BuiltValueNullFieldError.checkNotNull(
-                  eventKey, 'SeatingChartConfig', 'eventKey'),
+                  eventKey, r'SeatingChartConfig', 'eventKey'),
               chart: chart,
               region: region,
               language: language,
@@ -1862,7 +1864,7 @@ class SeatingChartConfigBuilder
               mode: mode,
               loading: loading,
               showLoadingAnimation: BuiltValueNullFieldError.checkNotNull(
-                  showLoadingAnimation, 'SeatingChartConfig', 'showLoadingAnimation'),
+                  showLoadingAnimation, r'SeatingChartConfig', 'showLoadingAnimation'),
               ticketListings: ticketListings,
               holdOnSelectForGAs: holdOnSelectForGAs,
               holdToken: holdToken,
@@ -1877,26 +1879,26 @@ class SeatingChartConfigBuilder
               showFullScreenButton: showFullScreenButton,
               channels: _channels?.build(),
               enableChartRenderedCallback: BuiltValueNullFieldError.checkNotNull(
-                  enableChartRenderedCallback, 'SeatingChartConfig', 'enableChartRenderedCallback'),
+                  enableChartRenderedCallback, r'SeatingChartConfig', 'enableChartRenderedCallback'),
               enableChartRenderingFailedCallback:
                   BuiltValueNullFieldError.checkNotNull(
                       enableChartRenderingFailedCallback,
-                      'SeatingChartConfig',
+                      r'SeatingChartConfig',
                       'enableChartRenderingFailedCallback'),
               enableObjectClickedCallback: BuiltValueNullFieldError.checkNotNull(
-                  enableObjectClickedCallback, 'SeatingChartConfig', 'enableObjectClickedCallback'),
+                  enableObjectClickedCallback, r'SeatingChartConfig', 'enableObjectClickedCallback'),
               enableObjectSelectedCallback:
-                  BuiltValueNullFieldError.checkNotNull(enableObjectSelectedCallback, 'SeatingChartConfig', 'enableObjectSelectedCallback'),
-              enableObjectDeselectedCallback: BuiltValueNullFieldError.checkNotNull(enableObjectDeselectedCallback, 'SeatingChartConfig', 'enableObjectDeselectedCallback'),
-              enableSelectionValidCallback: BuiltValueNullFieldError.checkNotNull(enableSelectionValidCallback, 'SeatingChartConfig', 'enableSelectionValidCallback'),
-              enableSelectionInvalidCallback: BuiltValueNullFieldError.checkNotNull(enableSelectionInvalidCallback, 'SeatingChartConfig', 'enableSelectionInvalidCallback'),
-              enableBestAvailableSelectedCallback: BuiltValueNullFieldError.checkNotNull(enableBestAvailableSelectedCallback, 'SeatingChartConfig', 'enableBestAvailableSelectedCallback'),
-              enableBestAvailableSelectionFailedCallback: BuiltValueNullFieldError.checkNotNull(enableBestAvailableSelectionFailedCallback, 'SeatingChartConfig', 'enableBestAvailableSelectionFailedCallback'),
-              enableHoldSucceededCallback: BuiltValueNullFieldError.checkNotNull(enableHoldSucceededCallback, 'SeatingChartConfig', 'enableHoldSucceededCallback'),
-              enableHoldFailedCallback: BuiltValueNullFieldError.checkNotNull(enableHoldFailedCallback, 'SeatingChartConfig', 'enableHoldFailedCallback'),
-              enableReleaseHoldSucceededCallback: BuiltValueNullFieldError.checkNotNull(enableReleaseHoldSucceededCallback, 'SeatingChartConfig', 'enableReleaseHoldSucceededCallback'),
-              enableReleaseHoldFailedCallback: BuiltValueNullFieldError.checkNotNull(enableReleaseHoldFailedCallback, 'SeatingChartConfig', 'enableReleaseHoldFailedCallback'),
-              enableSelectedObjectBookedCallback: BuiltValueNullFieldError.checkNotNull(enableSelectedObjectBookedCallback, 'SeatingChartConfig', 'enableSelectedObjectBookedCallback'));
+                  BuiltValueNullFieldError.checkNotNull(enableObjectSelectedCallback, r'SeatingChartConfig', 'enableObjectSelectedCallback'),
+              enableObjectDeselectedCallback: BuiltValueNullFieldError.checkNotNull(enableObjectDeselectedCallback, r'SeatingChartConfig', 'enableObjectDeselectedCallback'),
+              enableSelectionValidCallback: BuiltValueNullFieldError.checkNotNull(enableSelectionValidCallback, r'SeatingChartConfig', 'enableSelectionValidCallback'),
+              enableSelectionInvalidCallback: BuiltValueNullFieldError.checkNotNull(enableSelectionInvalidCallback, r'SeatingChartConfig', 'enableSelectionInvalidCallback'),
+              enableBestAvailableSelectedCallback: BuiltValueNullFieldError.checkNotNull(enableBestAvailableSelectedCallback, r'SeatingChartConfig', 'enableBestAvailableSelectedCallback'),
+              enableBestAvailableSelectionFailedCallback: BuiltValueNullFieldError.checkNotNull(enableBestAvailableSelectionFailedCallback, r'SeatingChartConfig', 'enableBestAvailableSelectionFailedCallback'),
+              enableHoldSucceededCallback: BuiltValueNullFieldError.checkNotNull(enableHoldSucceededCallback, r'SeatingChartConfig', 'enableHoldSucceededCallback'),
+              enableHoldFailedCallback: BuiltValueNullFieldError.checkNotNull(enableHoldFailedCallback, r'SeatingChartConfig', 'enableHoldFailedCallback'),
+              enableReleaseHoldSucceededCallback: BuiltValueNullFieldError.checkNotNull(enableReleaseHoldSucceededCallback, r'SeatingChartConfig', 'enableReleaseHoldSucceededCallback'),
+              enableReleaseHoldFailedCallback: BuiltValueNullFieldError.checkNotNull(enableReleaseHoldFailedCallback, r'SeatingChartConfig', 'enableReleaseHoldFailedCallback'),
+              enableSelectedObjectBookedCallback: BuiltValueNullFieldError.checkNotNull(enableSelectedObjectBookedCallback, r'SeatingChartConfig', 'enableSelectedObjectBookedCallback'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -1933,7 +1935,7 @@ class SeatingChartConfigBuilder
         _channels?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SeatingChartConfig', _$failedField, e.toString());
+            r'SeatingChartConfig', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -1951,15 +1953,15 @@ class _$SelectedObject extends SelectedObject {
   final String label;
 
   factory _$SelectedObject([void Function(SelectedObjectBuilder)? updates]) =>
-      (new SelectedObjectBuilder()..update(updates)).build();
+      (new SelectedObjectBuilder()..update(updates))._build();
 
   _$SelectedObject._(
       {required this.ticketType, required this.amount, required this.label})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        ticketType, 'SelectedObject', 'ticketType');
-    BuiltValueNullFieldError.checkNotNull(amount, 'SelectedObject', 'amount');
-    BuiltValueNullFieldError.checkNotNull(label, 'SelectedObject', 'label');
+        ticketType, r'SelectedObject', 'ticketType');
+    BuiltValueNullFieldError.checkNotNull(amount, r'SelectedObject', 'amount');
+    BuiltValueNullFieldError.checkNotNull(label, r'SelectedObject', 'label');
   }
 
   @override
@@ -1987,7 +1989,7 @@ class _$SelectedObject extends SelectedObject {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SelectedObject')
+    return (newBuiltValueToStringHelper(r'SelectedObject')
           ..add('ticketType', ticketType)
           ..add('amount', amount)
           ..add('label', label))
@@ -2036,15 +2038,17 @@ class SelectedObjectBuilder
   }
 
   @override
-  _$SelectedObject build() {
+  SelectedObject build() => _build();
+
+  _$SelectedObject _build() {
     final _$result = _$v ??
         new _$SelectedObject._(
             ticketType: BuiltValueNullFieldError.checkNotNull(
-                ticketType, 'SelectedObject', 'ticketType'),
+                ticketType, r'SelectedObject', 'ticketType'),
             amount: BuiltValueNullFieldError.checkNotNull(
-                amount, 'SelectedObject', 'amount'),
+                amount, r'SelectedObject', 'amount'),
             label: BuiltValueNullFieldError.checkNotNull(
-                label, 'SelectedObject', 'label'));
+                label, r'SelectedObject', 'label'));
     replace(_$result);
     return _$result;
   }
@@ -2069,7 +2073,7 @@ class _$ObjectTooltip extends ObjectTooltip {
   final bool confirmSelectionOnMobile;
 
   factory _$ObjectTooltip([void Function(ObjectTooltipBuilder)? updates]) =>
-      (new ObjectTooltipBuilder()..update(updates)).build();
+      (new ObjectTooltipBuilder()..update(updates))._build();
 
   _$ObjectTooltip._(
       {required this.showActionHint,
@@ -2082,21 +2086,21 @@ class _$ObjectTooltip extends ObjectTooltip {
       required this.confirmSelectionOnMobile})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        showActionHint, 'ObjectTooltip', 'showActionHint');
+        showActionHint, r'ObjectTooltip', 'showActionHint');
     BuiltValueNullFieldError.checkNotNull(
-        showAvailability, 'ObjectTooltip', 'showAvailability');
+        showAvailability, r'ObjectTooltip', 'showAvailability');
     BuiltValueNullFieldError.checkNotNull(
-        showCategory, 'ObjectTooltip', 'showCategory');
+        showCategory, r'ObjectTooltip', 'showCategory');
     BuiltValueNullFieldError.checkNotNull(
-        showLabel, 'ObjectTooltip', 'showLabel');
+        showLabel, r'ObjectTooltip', 'showLabel');
     BuiltValueNullFieldError.checkNotNull(
-        showPricing, 'ObjectTooltip', 'showPricing');
+        showPricing, r'ObjectTooltip', 'showPricing');
     BuiltValueNullFieldError.checkNotNull(
-        showUnavailableNotice, 'ObjectTooltip', 'showUnavailableNotice');
+        showUnavailableNotice, r'ObjectTooltip', 'showUnavailableNotice');
     BuiltValueNullFieldError.checkNotNull(
-        stylizedLabel, 'ObjectTooltip', 'stylizedLabel');
+        stylizedLabel, r'ObjectTooltip', 'stylizedLabel');
     BuiltValueNullFieldError.checkNotNull(
-        confirmSelectionOnMobile, 'ObjectTooltip', 'confirmSelectionOnMobile');
+        confirmSelectionOnMobile, r'ObjectTooltip', 'confirmSelectionOnMobile');
   }
 
   @override
@@ -2140,7 +2144,7 @@ class _$ObjectTooltip extends ObjectTooltip {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('ObjectTooltip')
+    return (newBuiltValueToStringHelper(r'ObjectTooltip')
           ..add('showActionHint', showActionHint)
           ..add('showAvailability', showAvailability)
           ..add('showCategory', showCategory)
@@ -2224,25 +2228,27 @@ class ObjectTooltipBuilder
   }
 
   @override
-  _$ObjectTooltip build() {
+  ObjectTooltip build() => _build();
+
+  _$ObjectTooltip _build() {
     final _$result = _$v ??
         new _$ObjectTooltip._(
             showActionHint: BuiltValueNullFieldError.checkNotNull(
-                showActionHint, 'ObjectTooltip', 'showActionHint'),
+                showActionHint, r'ObjectTooltip', 'showActionHint'),
             showAvailability: BuiltValueNullFieldError.checkNotNull(
-                showAvailability, 'ObjectTooltip', 'showAvailability'),
+                showAvailability, r'ObjectTooltip', 'showAvailability'),
             showCategory: BuiltValueNullFieldError.checkNotNull(
-                showCategory, 'ObjectTooltip', 'showCategory'),
+                showCategory, r'ObjectTooltip', 'showCategory'),
             showLabel: BuiltValueNullFieldError.checkNotNull(
-                showLabel, 'ObjectTooltip', 'showLabel'),
+                showLabel, r'ObjectTooltip', 'showLabel'),
             showPricing: BuiltValueNullFieldError.checkNotNull(
-                showPricing, 'ObjectTooltip', 'showPricing'),
+                showPricing, r'ObjectTooltip', 'showPricing'),
             showUnavailableNotice: BuiltValueNullFieldError.checkNotNull(
-                showUnavailableNotice, 'ObjectTooltip', 'showUnavailableNotice'),
+                showUnavailableNotice, r'ObjectTooltip', 'showUnavailableNotice'),
             stylizedLabel: BuiltValueNullFieldError.checkNotNull(
-                stylizedLabel, 'ObjectTooltip', 'stylizedLabel'),
+                stylizedLabel, r'ObjectTooltip', 'stylizedLabel'),
             confirmSelectionOnMobile: BuiltValueNullFieldError.checkNotNull(
-                confirmSelectionOnMobile, 'ObjectTooltip', 'confirmSelectionOnMobile'));
+                confirmSelectionOnMobile, r'ObjectTooltip', 'confirmSelectionOnMobile'));
     replace(_$result);
     return _$result;
   }
@@ -2256,15 +2262,15 @@ class _$LegendForCategory extends LegendForCategory {
 
   factory _$LegendForCategory(
           [void Function(LegendForCategoryBuilder)? updates]) =>
-      (new LegendForCategoryBuilder()..update(updates)).build();
+      (new LegendForCategoryBuilder()..update(updates))._build();
 
   _$LegendForCategory._(
       {required this.hideNonSelectableCategories, required this.hidePricing})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(hideNonSelectableCategories,
-        'LegendForCategory', 'hideNonSelectableCategories');
+        r'LegendForCategory', 'hideNonSelectableCategories');
     BuiltValueNullFieldError.checkNotNull(
-        hidePricing, 'LegendForCategory', 'hidePricing');
+        hidePricing, r'LegendForCategory', 'hidePricing');
   }
 
   @override
@@ -2291,7 +2297,7 @@ class _$LegendForCategory extends LegendForCategory {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('LegendForCategory')
+    return (newBuiltValueToStringHelper(r'LegendForCategory')
           ..add('hideNonSelectableCategories', hideNonSelectableCategories)
           ..add('hidePricing', hidePricing))
         .toString();
@@ -2335,15 +2341,17 @@ class LegendForCategoryBuilder
   }
 
   @override
-  _$LegendForCategory build() {
+  LegendForCategory build() => _build();
+
+  _$LegendForCategory _build() {
     final _$result = _$v ??
         new _$LegendForCategory._(
             hideNonSelectableCategories: BuiltValueNullFieldError.checkNotNull(
                 hideNonSelectableCategories,
-                'LegendForCategory',
+                r'LegendForCategory',
                 'hideNonSelectableCategories'),
             hidePricing: BuiltValueNullFieldError.checkNotNull(
-                hidePricing, 'LegendForCategory', 'hidePricing'));
+                hidePricing, r'LegendForCategory', 'hidePricing'));
     replace(_$result);
     return _$result;
   }
@@ -2360,7 +2368,7 @@ class _$BestAvailable extends BestAvailable {
   final bool clearSelection;
 
   factory _$BestAvailable([void Function(BestAvailableBuilder)? updates]) =>
-      (new BestAvailableBuilder()..update(updates)).build();
+      (new BestAvailableBuilder()..update(updates))._build();
 
   _$BestAvailable._(
       {required this.number,
@@ -2368,13 +2376,13 @@ class _$BestAvailable extends BestAvailable {
       required this.ticketTypes,
       required this.clearSelection})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(number, 'BestAvailable', 'number');
+    BuiltValueNullFieldError.checkNotNull(number, r'BestAvailable', 'number');
     BuiltValueNullFieldError.checkNotNull(
-        category, 'BestAvailable', 'category');
+        category, r'BestAvailable', 'category');
     BuiltValueNullFieldError.checkNotNull(
-        ticketTypes, 'BestAvailable', 'ticketTypes');
+        ticketTypes, r'BestAvailable', 'ticketTypes');
     BuiltValueNullFieldError.checkNotNull(
-        clearSelection, 'BestAvailable', 'clearSelection');
+        clearSelection, r'BestAvailable', 'clearSelection');
   }
 
   @override
@@ -2404,7 +2412,7 @@ class _$BestAvailable extends BestAvailable {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('BestAvailable')
+    return (newBuiltValueToStringHelper(r'BestAvailable')
           ..add('number', number)
           ..add('category', category)
           ..add('ticketTypes', ticketTypes)
@@ -2463,17 +2471,19 @@ class BestAvailableBuilder
   }
 
   @override
-  _$BestAvailable build() {
+  BestAvailable build() => _build();
+
+  _$BestAvailable _build() {
     _$BestAvailable _$result;
     try {
       _$result = _$v ??
           new _$BestAvailable._(
               number: BuiltValueNullFieldError.checkNotNull(
-                  number, 'BestAvailable', 'number'),
+                  number, r'BestAvailable', 'number'),
               category: category.build(),
               ticketTypes: ticketTypes.build(),
               clearSelection: BuiltValueNullFieldError.checkNotNull(
-                  clearSelection, 'BestAvailable', 'clearSelection'));
+                  clearSelection, r'BestAvailable', 'clearSelection'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -2483,7 +2493,7 @@ class BestAvailableBuilder
         ticketTypes.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'BestAvailable', _$failedField, e.toString());
+            r'BestAvailable', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -2498,10 +2508,10 @@ class _$SelectionValidator extends SelectionValidator {
 
   factory _$SelectionValidator(
           [void Function(SelectionValidatorBuilder)? updates]) =>
-      (new SelectionValidatorBuilder()..update(updates)).build();
+      (new SelectionValidatorBuilder()..update(updates))._build();
 
   _$SelectionValidator._({required this.type}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(type, 'SelectionValidator', 'type');
+    BuiltValueNullFieldError.checkNotNull(type, r'SelectionValidator', 'type');
   }
 
   @override
@@ -2526,7 +2536,7 @@ class _$SelectionValidator extends SelectionValidator {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SelectionValidator')
+    return (newBuiltValueToStringHelper(r'SelectionValidator')
           ..add('type', type))
         .toString();
   }
@@ -2563,11 +2573,13 @@ class SelectionValidatorBuilder
   }
 
   @override
-  _$SelectionValidator build() {
+  SelectionValidator build() => _build();
+
+  _$SelectionValidator _build() {
     final _$result = _$v ??
         new _$SelectionValidator._(
             type: BuiltValueNullFieldError.checkNotNull(
-                type, 'SelectionValidator', 'type'));
+                type, r'SelectionValidator', 'type'));
     replace(_$result);
     return _$result;
   }
@@ -2582,15 +2594,15 @@ class _$TicketListing extends TicketListing {
   final double price;
 
   factory _$TicketListing([void Function(TicketListingBuilder)? updates]) =>
-      (new TicketListingBuilder()..update(updates)).build();
+      (new TicketListingBuilder()..update(updates))._build();
 
   _$TicketListing._(
       {required this.section, required this.quantity, required this.price})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(section, 'TicketListing', 'section');
+    BuiltValueNullFieldError.checkNotNull(section, r'TicketListing', 'section');
     BuiltValueNullFieldError.checkNotNull(
-        quantity, 'TicketListing', 'quantity');
-    BuiltValueNullFieldError.checkNotNull(price, 'TicketListing', 'price');
+        quantity, r'TicketListing', 'quantity');
+    BuiltValueNullFieldError.checkNotNull(price, r'TicketListing', 'price');
   }
 
   @override
@@ -2617,7 +2629,7 @@ class _$TicketListing extends TicketListing {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('TicketListing')
+    return (newBuiltValueToStringHelper(r'TicketListing')
           ..add('section', section)
           ..add('quantity', quantity)
           ..add('price', price))
@@ -2666,18 +2678,20 @@ class TicketListingBuilder
   }
 
   @override
-  _$TicketListing build() {
+  TicketListing build() => _build();
+
+  _$TicketListing _build() {
     final _$result = _$v ??
         new _$TicketListing._(
             section: BuiltValueNullFieldError.checkNotNull(
-                section, 'TicketListing', 'section'),
+                section, r'TicketListing', 'section'),
             quantity: BuiltValueNullFieldError.checkNotNull(
-                quantity, 'TicketListing', 'quantity'),
+                quantity, r'TicketListing', 'quantity'),
             price: BuiltValueNullFieldError.checkNotNull(
-                price, 'TicketListing', 'price'));
+                price, r'TicketListing', 'price'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seating_config_change.g.dart
+++ b/lib/src/models/seating_config_change.g.dart
@@ -95,7 +95,7 @@ class _$SeatingConfigChangeSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -165,7 +165,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
 
   factory _$SeatingConfigChange(
           [void Function(SeatingConfigChangeBuilder)? updates]) =>
-      (new SeatingConfigChangeBuilder()..update(updates)).build();
+      (new SeatingConfigChangeBuilder()..update(updates))._build();
 
   _$SeatingConfigChange._(
       {this.objectColor,
@@ -221,7 +221,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatingConfigChange')
+    return (newBuiltValueToStringHelper(r'SeatingConfigChange')
           ..add('objectColor', objectColor)
           ..add('objectLabel', objectLabel)
           ..add('objectIcon', objectIcon)
@@ -309,7 +309,9 @@ class SeatingConfigChangeBuilder
   }
 
   @override
-  _$SeatingConfigChange build() {
+  SeatingConfigChange build() => _build();
+
+  _$SeatingConfigChange _build() {
     _$SeatingConfigChange _$result;
     try {
       _$result = _$v ??
@@ -335,7 +337,7 @@ class SeatingConfigChangeBuilder
         _filteredCategories?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SeatingConfigChange', _$failedField, e.toString());
+            r'SeatingConfigChange', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -344,4 +346,4 @@ class SeatingConfigChangeBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_category.g.dart
+++ b/lib/src/models/seatsio_category.g.dart
@@ -70,13 +70,13 @@ class _$SeatsioCategorySerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'key':
           result.key = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'label':
           result.label = serializers.deserialize(value,
@@ -121,7 +121,7 @@ class _$SeatsioCategory extends SeatsioCategory {
   final bool? isFiltered;
 
   factory _$SeatsioCategory([void Function(SeatsioCategoryBuilder)? updates]) =>
-      (new SeatsioCategoryBuilder()..update(updates)).build();
+      (new SeatsioCategoryBuilder()..update(updates))._build();
 
   _$SeatsioCategory._(
       {required this.key,
@@ -131,7 +131,7 @@ class _$SeatsioCategory extends SeatsioCategory {
       this.accessible,
       this.isFiltered})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(key, 'SeatsioCategory', 'key');
+    BuiltValueNullFieldError.checkNotNull(key, r'SeatsioCategory', 'key');
   }
 
   @override
@@ -166,7 +166,7 @@ class _$SeatsioCategory extends SeatsioCategory {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatsioCategory')
+    return (newBuiltValueToStringHelper(r'SeatsioCategory')
           ..add('key', key)
           ..add('label', label)
           ..add('color', color)
@@ -234,13 +234,15 @@ class SeatsioCategoryBuilder
   }
 
   @override
-  _$SeatsioCategory build() {
+  SeatsioCategory build() => _build();
+
+  _$SeatsioCategory _build() {
     _$SeatsioCategory _$result;
     try {
       _$result = _$v ??
           new _$SeatsioCategory._(
               key: BuiltValueNullFieldError.checkNotNull(
-                  key, 'SeatsioCategory', 'key'),
+                  key, r'SeatsioCategory', 'key'),
               label: label,
               color: color,
               pricing: _pricing?.build(),
@@ -253,7 +255,7 @@ class SeatsioCategoryBuilder
         _pricing?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SeatsioCategory', _$failedField, e.toString());
+            r'SeatsioCategory', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -262,4 +264,4 @@ class SeatsioCategoryBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_label.g.dart
+++ b/lib/src/models/seatsio_label.g.dart
@@ -51,17 +51,17 @@ class _$SeatsioLabelSerializer implements StructuredSerializer<SeatsioLabel> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'own':
           result.own = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'parent':
           result.parent = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'section':
           result.section = serializers.deserialize(value,
@@ -89,7 +89,7 @@ class _$SeatsioLabel extends SeatsioLabel {
   final String? displayedLabel;
 
   factory _$SeatsioLabel([void Function(SeatsioLabelBuilder)? updates]) =>
-      (new SeatsioLabelBuilder()..update(updates)).build();
+      (new SeatsioLabelBuilder()..update(updates))._build();
 
   _$SeatsioLabel._(
       {required this.own,
@@ -97,8 +97,8 @@ class _$SeatsioLabel extends SeatsioLabel {
       this.section,
       this.displayedLabel})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(own, 'SeatsioLabel', 'own');
-    BuiltValueNullFieldError.checkNotNull(parent, 'SeatsioLabel', 'parent');
+    BuiltValueNullFieldError.checkNotNull(own, r'SeatsioLabel', 'own');
+    BuiltValueNullFieldError.checkNotNull(parent, r'SeatsioLabel', 'parent');
   }
 
   @override
@@ -127,7 +127,7 @@ class _$SeatsioLabel extends SeatsioLabel {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatsioLabel')
+    return (newBuiltValueToStringHelper(r'SeatsioLabel')
           ..add('own', own)
           ..add('parent', parent)
           ..add('section', section)
@@ -183,13 +183,15 @@ class SeatsioLabelBuilder
   }
 
   @override
-  _$SeatsioLabel build() {
+  SeatsioLabel build() => _build();
+
+  _$SeatsioLabel _build() {
     final _$result = _$v ??
         new _$SeatsioLabel._(
             own: BuiltValueNullFieldError.checkNotNull(
-                own, 'SeatsioLabel', 'own'),
+                own, r'SeatsioLabel', 'own'),
             parent: BuiltValueNullFieldError.checkNotNull(
-                parent, 'SeatsioLabel', 'parent'),
+                parent, r'SeatsioLabel', 'parent'),
             section: section,
             displayedLabel: displayedLabel);
     replace(_$result);
@@ -197,4 +199,4 @@ class SeatsioLabelBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_object.g.dart
+++ b/lib/src/models/seatsio_object.g.dart
@@ -80,25 +80,25 @@ class _$SeatsioObjectSerializer implements StructuredSerializer<SeatsioObject> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'uuid':
           result.uuid = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'objectType':
           result.objectType = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'label':
           result.label = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'labels':
           result.labelDetail.replace(serializers.deserialize(value,
@@ -115,15 +115,15 @@ class _$SeatsioObjectSerializer implements StructuredSerializer<SeatsioObject> {
           break;
         case 'status':
           result.status = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'forSale':
           result.forSale = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'selectable':
           result.selectable = serializers.deserialize(value,
-              specifiedType: const FullType(bool)) as bool;
+              specifiedType: const FullType(bool))! as bool;
           break;
         case 'seats':
           result.seats = serializers.deserialize(value,
@@ -163,7 +163,7 @@ class _$SeatsioObject extends SeatsioObject {
   final List<SeatsioObject>? seats;
 
   factory _$SeatsioObject([void Function(SeatsioObjectBuilder)? updates]) =>
-      (new SeatsioObjectBuilder()..update(updates)).build();
+      (new SeatsioObjectBuilder()..update(updates))._build();
 
   _$SeatsioObject._(
       {required this.id,
@@ -178,15 +178,15 @@ class _$SeatsioObject extends SeatsioObject {
       required this.selectable,
       this.seats})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'SeatsioObject', 'id');
-    BuiltValueNullFieldError.checkNotNull(uuid, 'SeatsioObject', 'uuid');
+    BuiltValueNullFieldError.checkNotNull(id, r'SeatsioObject', 'id');
+    BuiltValueNullFieldError.checkNotNull(uuid, r'SeatsioObject', 'uuid');
     BuiltValueNullFieldError.checkNotNull(
-        objectType, 'SeatsioObject', 'objectType');
-    BuiltValueNullFieldError.checkNotNull(label, 'SeatsioObject', 'label');
-    BuiltValueNullFieldError.checkNotNull(status, 'SeatsioObject', 'status');
-    BuiltValueNullFieldError.checkNotNull(forSale, 'SeatsioObject', 'forSale');
+        objectType, r'SeatsioObject', 'objectType');
+    BuiltValueNullFieldError.checkNotNull(label, r'SeatsioObject', 'label');
+    BuiltValueNullFieldError.checkNotNull(status, r'SeatsioObject', 'status');
+    BuiltValueNullFieldError.checkNotNull(forSale, r'SeatsioObject', 'forSale');
     BuiltValueNullFieldError.checkNotNull(
-        selectable, 'SeatsioObject', 'selectable');
+        selectable, r'SeatsioObject', 'selectable');
   }
 
   @override
@@ -237,7 +237,7 @@ class _$SeatsioObject extends SeatsioObject {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatsioObject')
+    return (newBuiltValueToStringHelper(r'SeatsioObject')
           ..add('id', id)
           ..add('uuid', uuid)
           ..add('objectType', objectType)
@@ -338,28 +338,30 @@ class SeatsioObjectBuilder
   }
 
   @override
-  _$SeatsioObject build() {
+  SeatsioObject build() => _build();
+
+  _$SeatsioObject _build() {
     _$SeatsioObject _$result;
     try {
       _$result = _$v ??
           new _$SeatsioObject._(
               id: BuiltValueNullFieldError.checkNotNull(
-                  id, 'SeatsioObject', 'id'),
+                  id, r'SeatsioObject', 'id'),
               uuid: BuiltValueNullFieldError.checkNotNull(
-                  uuid, 'SeatsioObject', 'uuid'),
+                  uuid, r'SeatsioObject', 'uuid'),
               objectType: BuiltValueNullFieldError.checkNotNull(
-                  objectType, 'SeatsioObject', 'objectType'),
+                  objectType, r'SeatsioObject', 'objectType'),
               label: BuiltValueNullFieldError.checkNotNull(
-                  label, 'SeatsioObject', 'label'),
+                  label, r'SeatsioObject', 'label'),
               labelDetail: _labelDetail?.build(),
               category: _category?.build(),
               center: _center?.build(),
               status: BuiltValueNullFieldError.checkNotNull(
-                  status, 'SeatsioObject', 'status'),
+                  status, r'SeatsioObject', 'status'),
               forSale: BuiltValueNullFieldError.checkNotNull(
-                  forSale, 'SeatsioObject', 'forSale'),
+                  forSale, r'SeatsioObject', 'forSale'),
               selectable: BuiltValueNullFieldError.checkNotNull(
-                  selectable, 'SeatsioObject', 'selectable'),
+                  selectable, r'SeatsioObject', 'selectable'),
               seats: seats);
     } catch (_) {
       late String _$failedField;
@@ -372,7 +374,7 @@ class SeatsioObjectBuilder
         _center?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SeatsioObject', _$failedField, e.toString());
+            r'SeatsioObject', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -381,4 +383,4 @@ class SeatsioObjectBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_point.g.dart
+++ b/lib/src/models/seatsio_point.g.dart
@@ -36,17 +36,17 @@ class _$SeatsioPointSerializer implements StructuredSerializer<SeatsioPoint> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'x':
           result.x = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
         case 'y':
           result.y = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
       }
     }
@@ -62,11 +62,11 @@ class _$SeatsioPoint extends SeatsioPoint {
   final double y;
 
   factory _$SeatsioPoint([void Function(SeatsioPointBuilder)? updates]) =>
-      (new SeatsioPointBuilder()..update(updates)).build();
+      (new SeatsioPointBuilder()..update(updates))._build();
 
   _$SeatsioPoint._({required this.x, required this.y}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(x, 'SeatsioPoint', 'x');
-    BuiltValueNullFieldError.checkNotNull(y, 'SeatsioPoint', 'y');
+    BuiltValueNullFieldError.checkNotNull(x, r'SeatsioPoint', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'SeatsioPoint', 'y');
   }
 
   @override
@@ -89,7 +89,7 @@ class _$SeatsioPoint extends SeatsioPoint {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatsioPoint')
+    return (newBuiltValueToStringHelper(r'SeatsioPoint')
           ..add('x', x)
           ..add('y', y))
         .toString();
@@ -132,14 +132,16 @@ class SeatsioPointBuilder
   }
 
   @override
-  _$SeatsioPoint build() {
+  SeatsioPoint build() => _build();
+
+  _$SeatsioPoint _build() {
     final _$result = _$v ??
         new _$SeatsioPoint._(
-            x: BuiltValueNullFieldError.checkNotNull(x, 'SeatsioPoint', 'x'),
-            y: BuiltValueNullFieldError.checkNotNull(y, 'SeatsioPoint', 'y'));
+            x: BuiltValueNullFieldError.checkNotNull(x, r'SeatsioPoint', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'SeatsioPoint', 'y'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_serializers.g.dart
+++ b/lib/src/models/seatsio_serializers.g.dart
@@ -58,4 +58,4 @@ Serializers _$serializers = (new Serializers().toBuilder()
           () => new ListBuilder<TicketTypePricing>()))
     .build();
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/models/seatsio_ticket_type.g.dart
+++ b/lib/src/models/seatsio_ticket_type.g.dart
@@ -39,17 +39,17 @@ class _$SeatsioTicketTypeSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'price':
           result.price = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
         case 'ticketType':
           result.ticketType = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -66,13 +66,13 @@ class _$SeatsioTicketType extends SeatsioTicketType {
 
   factory _$SeatsioTicketType(
           [void Function(SeatsioTicketTypeBuilder)? updates]) =>
-      (new SeatsioTicketTypeBuilder()..update(updates)).build();
+      (new SeatsioTicketTypeBuilder()..update(updates))._build();
 
   _$SeatsioTicketType._({required this.price, required this.ticketType})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(price, 'SeatsioTicketType', 'price');
+    BuiltValueNullFieldError.checkNotNull(price, r'SeatsioTicketType', 'price');
     BuiltValueNullFieldError.checkNotNull(
-        ticketType, 'SeatsioTicketType', 'ticketType');
+        ticketType, r'SeatsioTicketType', 'ticketType');
   }
 
   @override
@@ -98,7 +98,7 @@ class _$SeatsioTicketType extends SeatsioTicketType {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SeatsioTicketType')
+    return (newBuiltValueToStringHelper(r'SeatsioTicketType')
           ..add('price', price)
           ..add('ticketType', ticketType))
         .toString();
@@ -141,16 +141,18 @@ class SeatsioTicketTypeBuilder
   }
 
   @override
-  _$SeatsioTicketType build() {
+  SeatsioTicketType build() => _build();
+
+  _$SeatsioTicketType _build() {
     final _$result = _$v ??
         new _$SeatsioTicketType._(
             price: BuiltValueNullFieldError.checkNotNull(
-                price, 'SeatsioTicketType', 'price'),
+                price, r'SeatsioTicketType', 'price'),
             ticketType: BuiltValueNullFieldError.checkNotNull(
-                ticketType, 'SeatsioTicketType', 'ticketType'));
+                ticketType, r'SeatsioTicketType', 'ticketType'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/ui/seatsio_web_view.dart
+++ b/lib/src/ui/seatsio_web_view.dart
@@ -280,8 +280,13 @@ class _SeatsioWebViewState extends State<SeatsioWebView> {
           if (widget._enableDebug)
             debugPrint(
                 "[Seatsio]-> onHoldSucceeded callback message: ${message.message}");
-          // todo: get objects and types from message
-          widget._onHoldSucceeded?.call([], null);
+          // todo: what about ticket types?
+          final objects = SeatsioObject.arrayFromJson(message.message);
+          if (objects != null) {
+            widget._onHoldSucceeded?.call(objects, null);
+          } else {
+            widget._onHoldSucceeded?.call([], null);
+          }
         },
       ));
     }
@@ -293,8 +298,13 @@ class _SeatsioWebViewState extends State<SeatsioWebView> {
           if (widget._enableDebug)
             debugPrint(
                 "[Seatsio]-> onHoldFailed callback message: ${message.message}");
-          // todo: get objects and types from message
-          widget._onHoldFailed?.call([], null);
+          // todo: what about ticket types?
+          final objects = SeatsioObject.arrayFromJson(message.message);
+          if (objects != null) {
+            widget._onHoldFailed?.call(objects, null);
+          } else {
+            widget._onHoldFailed?.call([], null);
+          }
         },
       ));
     }


### PR DESCRIPTION
- changed price field on PriceCategory to num (previously double) because it was converted to int even forcing it to be double in the client application
- added a categoryKey field (not sure if that would be the best way) since SeatsIO accepts two types of identifiers for categories; keys and labels, but keys are integers so I added this extra field since changing category field to dynamic appears to break the generated built class contract
- sending parameters into onHoldSucceeded/onHoldFailed callbacks

*also had to bump some dependencies versions on the android example app as it was not compiling