### PR TITLE
Expose WebView.gestureRecognizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+* 🆕 Expose WebView.gestureRecognizers property.
+
 ## 0.3.1
 * 🐞 Different coordinate types.
 

--- a/lib/src/ui/seatsio_web_view.dart
+++ b/lib/src/ui/seatsio_web_view.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+
 import '../models/seating_chart.dart';
-import '../models/seatsio_category.dart';
 import '../models/seating_chart_config.dart';
+import '../models/seatsio_category.dart';
 import '../models/seatsio_object.dart';
 import '../util/seatsio_web_view_controller.dart';
 
@@ -28,6 +32,7 @@ class SeatsioWebView extends StatefulWidget {
     SeatsioObjectsTicketTypesCallback? onReleaseHoldSucceeded,
     SeatsioObjectsTicketTypesCallback? onReleaseHoldFailed,
     SeatsioObjectCallback? onSelectedObjectBooked,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
   })  : this._enableDebug = enableDebug,
         this._initialUrl = initialUrl,
         this._onWebViewCreated = onWebViewCreated,
@@ -46,6 +51,7 @@ class SeatsioWebView extends StatefulWidget {
         this._onReleaseHoldSucceeded = onReleaseHoldSucceeded,
         this._onReleaseHoldFailed = onReleaseHoldFailed,
         this._onSelectedObjectBooked = onSelectedObjectBooked,
+        this._gestureRecognizers = gestureRecognizers,
         super(key: key);
 
   /// Output some log if setting the [enableDebug] to true.
@@ -91,6 +97,8 @@ class SeatsioWebView extends StatefulWidget {
 
   final SeatsioObjectCallback? _onSelectedObjectBooked;
 
+  final Set<Factory<OneSequenceGestureRecognizer>>? _gestureRecognizers;
+
   @override
   State<StatefulWidget> createState() => _SeatsioWebViewState();
 }
@@ -118,6 +126,7 @@ class _SeatsioWebViewState extends State<SeatsioWebView> {
         widget._onWebViewCreated?.call(_seatsioController);
       },
       javascriptChannels: _javascriptChannels(),
+      gestureRecognizers: widget._gestureRecognizers,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: seatsio
 description: Seatsio SDK for Flutter.
 repository: https://github.com/SongJiaqiang/seatsio-flutter
-version: 0.3.1
+version: 0.3.2
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
When `SeatsioWebView` is used in a `ListView` or `GridView`, it's useful to fine tune gesture recognizing to avoid conflicts. `WebView` already has a built-in mechanism for that.

This PR does nothing but exposes the `WebView.gestureRecognizers` property to `SeatsioWebVIew` users.