### PR TITLE
"maxSelectedObjects" supports both types int and List<Map<String, dynamic>>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 0.3.4
+* 🐞 "maxSelectedObjects" supports both types int and List<Map<String, dynamic>>.
+
 ## 0.3.3
 * 🆕 Add more attributes.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  seatsio: ^0.3.0
+  seatsio: ^0.3.4
 ```
 
 Then, import `seatsio` package to your dart file.

--- a/lib/src/models/seating_chart_config.dart
+++ b/lib/src/models/seating_chart_config.dart
@@ -114,11 +114,11 @@ abstract class SeatingChartConfig
 
   String? get priceLevelsTooltipMessage;
 
-  /// [maxSelectedObjects] is an unverified attribute.
-  /// If you have any questions, you are welcome to ask your questions, or directly submit a pull request to the git repository.
-  /// https://github.com/SongJiaqiang/seatsio-flutter/issues
   /// See more: https://docs.seats.io/docs/renderer/config-maxselectedobjects/
-  BuiltList<BuiltMap<String, dynamic>>? get maxSelectedObjects;
+  int? get maxSelectedObjects;
+
+  /// If [maxSelectedObjectList] is not null, it replaces [maxSelectedObjectList].
+  List<Map<String, dynamic>>? get maxSelectedObjectList;
 
   /// See more: https://docs.seats.io/docs/renderer/availablecategories/
   BuiltList<String>? get availableCategories;
@@ -301,8 +301,10 @@ abstract class SeatingChartConfig
       }
     }
 
-    if (maxSelectedObjects != null) {
-      configMap["maxSelectedObjects"] = maxSelectedObjects!;
+    if (maxSelectedObjectList != null) {
+      configMap["maxSelectedObjects"] = maxSelectedObjectList;
+    } else if (maxSelectedObjects != null) {
+      configMap["maxSelectedObjects"] = maxSelectedObjects;
     }
 
     if (extraConfig != null) {

--- a/lib/src/models/seating_chart_config.g.dart
+++ b/lib/src/models/seating_chart_config.g.dart
@@ -183,10 +183,16 @@ class _$SeatingChartConfigSerializer
     if (value != null) {
       result
         ..add('maxSelectedObjects')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.maxSelectedObjectList;
+    if (value != null) {
+      result
+        ..add('maxSelectedObjectList')
         ..add(serializers.serialize(value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(BuiltMap,
-                  const [const FullType(String), const FullType(dynamic)])
+            specifiedType: const FullType(List, const [
+              const FullType(
+                  Map, const [const FullType(String), const FullType(dynamic)])
             ])));
     }
     value = object.availableCategories;
@@ -474,11 +480,15 @@ class _$SeatingChartConfigSerializer
               specifiedType: const FullType(String)) as String?;
           break;
         case 'maxSelectedObjects':
-          result.maxSelectedObjects.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltList, const [
-                const FullType(BuiltMap,
+          result.maxSelectedObjects = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+        case 'maxSelectedObjectList':
+          result.maxSelectedObjectList = serializers.deserialize(value,
+              specifiedType: const FullType(List, const [
+                const FullType(Map,
                     const [const FullType(String), const FullType(dynamic)])
-              ]))! as BuiltList<Object?>);
+              ])) as List<Map<String, dynamic>>?;
           break;
         case 'availableCategories':
           result.availableCategories.replace(serializers.deserialize(value,
@@ -1070,7 +1080,9 @@ class _$SeatingChartConfig extends SeatingChartConfig {
   @override
   final String? priceLevelsTooltipMessage;
   @override
-  final BuiltList<BuiltMap<String, dynamic>>? maxSelectedObjects;
+  final int? maxSelectedObjects;
+  @override
+  final List<Map<String, dynamic>>? maxSelectedObjectList;
   @override
   final BuiltList<String>? availableCategories;
   @override
@@ -1179,6 +1191,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
       this.messages,
       this.priceLevelsTooltipMessage,
       this.maxSelectedObjects,
+      this.maxSelectedObjectList,
       this.availableCategories,
       this.unavailableCategories,
       this.selectBestAvailable,
@@ -1292,6 +1305,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
         messages == other.messages &&
         priceLevelsTooltipMessage == other.priceLevelsTooltipMessage &&
         maxSelectedObjects == other.maxSelectedObjects &&
+        maxSelectedObjectList == other.maxSelectedObjectList &&
         availableCategories == other.availableCategories &&
         unavailableCategories == other.unavailableCategories &&
         selectBestAvailable == other.selectBestAvailable &&
@@ -1364,6 +1378,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
     _$hash = $jc(_$hash, messages.hashCode);
     _$hash = $jc(_$hash, priceLevelsTooltipMessage.hashCode);
     _$hash = $jc(_$hash, maxSelectedObjects.hashCode);
+    _$hash = $jc(_$hash, maxSelectedObjectList.hashCode);
     _$hash = $jc(_$hash, availableCategories.hashCode);
     _$hash = $jc(_$hash, unavailableCategories.hashCode);
     _$hash = $jc(_$hash, selectBestAvailable.hashCode);
@@ -1432,6 +1447,7 @@ class _$SeatingChartConfig extends SeatingChartConfig {
           ..add('messages', messages)
           ..add('priceLevelsTooltipMessage', priceLevelsTooltipMessage)
           ..add('maxSelectedObjects', maxSelectedObjects)
+          ..add('maxSelectedObjectList', maxSelectedObjectList)
           ..add('availableCategories', availableCategories)
           ..add('unavailableCategories', unavailableCategories)
           ..add('selectBestAvailable', selectBestAvailable)
@@ -1565,13 +1581,17 @@ class SeatingChartConfigBuilder
   set priceLevelsTooltipMessage(String? priceLevelsTooltipMessage) =>
       _$this._priceLevelsTooltipMessage = priceLevelsTooltipMessage;
 
-  ListBuilder<BuiltMap<String, dynamic>>? _maxSelectedObjects;
-  ListBuilder<BuiltMap<String, dynamic>> get maxSelectedObjects =>
-      _$this._maxSelectedObjects ??=
-          new ListBuilder<BuiltMap<String, dynamic>>();
-  set maxSelectedObjects(
-          ListBuilder<BuiltMap<String, dynamic>>? maxSelectedObjects) =>
+  int? _maxSelectedObjects;
+  int? get maxSelectedObjects => _$this._maxSelectedObjects;
+  set maxSelectedObjects(int? maxSelectedObjects) =>
       _$this._maxSelectedObjects = maxSelectedObjects;
+
+  List<Map<String, dynamic>>? _maxSelectedObjectList;
+  List<Map<String, dynamic>>? get maxSelectedObjectList =>
+      _$this._maxSelectedObjectList;
+  set maxSelectedObjectList(
+          List<Map<String, dynamic>>? maxSelectedObjectList) =>
+      _$this._maxSelectedObjectList = maxSelectedObjectList;
 
   ListBuilder<String>? _availableCategories;
   ListBuilder<String> get availableCategories =>
@@ -1826,7 +1846,8 @@ class SeatingChartConfigBuilder
       _themeColor = $v.themeColor;
       _messages = $v.messages?.toBuilder();
       _priceLevelsTooltipMessage = $v.priceLevelsTooltipMessage;
-      _maxSelectedObjects = $v.maxSelectedObjects?.toBuilder();
+      _maxSelectedObjects = $v.maxSelectedObjects;
+      _maxSelectedObjectList = $v.maxSelectedObjectList;
       _availableCategories = $v.availableCategories?.toBuilder();
       _unavailableCategories = $v.unavailableCategories?.toBuilder();
       _selectBestAvailable = $v.selectBestAvailable?.toBuilder();
@@ -1916,7 +1937,8 @@ class SeatingChartConfigBuilder
               themeColor: themeColor,
               messages: _messages?.build(),
               priceLevelsTooltipMessage: priceLevelsTooltipMessage,
-              maxSelectedObjects: _maxSelectedObjects?.build(),
+              maxSelectedObjects: maxSelectedObjects,
+              maxSelectedObjectList: maxSelectedObjectList,
               availableCategories: _availableCategories?.build(),
               unavailableCategories: _unavailableCategories?.build(),
               selectBestAvailable: _selectBestAvailable?.build(),
@@ -1982,8 +2004,6 @@ class SeatingChartConfigBuilder
         _$failedField = 'messages';
         _messages?.build();
 
-        _$failedField = 'maxSelectedObjects';
-        _maxSelectedObjects?.build();
         _$failedField = 'availableCategories';
         _availableCategories?.build();
         _$failedField = 'unavailableCategories';

--- a/lib/src/models/seating_config_change.dart
+++ b/lib/src/models/seating_config_change.dart
@@ -17,11 +17,11 @@ abstract class SeatingConfigChange
 
   String? get objectIcon;
 
-  /// [maxSelectedObjects] is an unverified attribute.
-  /// If you have any questions, you are welcome to ask your questions, or directly submit a pull request to the git repository.
-  /// https://github.com/SongJiaqiang/seatsio-flutter/issues
   /// See more: https://docs.seats.io/docs/renderer/config-maxselectedobjects/
-  List<Map<String, dynamic>>? get maxSelectedObjects;
+  int? get maxSelectedObjects;
+
+  /// If [maxSelectedObjectList] is not null, it replaces [maxSelectedObjectList].
+  List<Map<String, dynamic>>? get maxSelectedObjectList;
 
   BuiltMap<String, String>? get extraConfig;
 
@@ -36,19 +36,21 @@ abstract class SeatingConfigChange
     final Map<String, Object?> configMap = {};
 
     if (objectColor != null) {
-      configMap["objectColor"] = objectColor!;
+      configMap["objectColor"] = objectColor;
     }
 
     if (objectIcon != null) {
-      configMap["objectIcon"] = objectIcon!;
+      configMap["objectIcon"] = objectIcon;
     }
 
     if (objectLabel != null) {
-      configMap["objectLabel"] = objectLabel!;
+      configMap["objectLabel"] = objectLabel;
     }
 
-    if (maxSelectedObjects != null) {
-      configMap["maxSelectedObjects"] = maxSelectedObjects!;
+    if (maxSelectedObjectList != null) {
+      configMap["maxSelectedObjects"] = maxSelectedObjectList;
+    } else if (maxSelectedObjects != null) {
+      configMap["maxSelectedObjects"] = maxSelectedObjects;
     }
 
     if (extraConfig != null) {

--- a/lib/src/models/seating_config_change.g.dart
+++ b/lib/src/models/seating_config_change.g.dart
@@ -50,6 +50,12 @@ class _$SeatingConfigChangeSerializer
     if (value != null) {
       result
         ..add('maxSelectedObjects')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.maxSelectedObjectList;
+    if (value != null) {
+      result
+        ..add('maxSelectedObjectList')
         ..add(serializers.serialize(value,
             specifiedType: const FullType(List, const [
               const FullType(
@@ -117,6 +123,10 @@ class _$SeatingConfigChangeSerializer
           break;
         case 'maxSelectedObjects':
           result.maxSelectedObjects = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+        case 'maxSelectedObjectList':
+          result.maxSelectedObjectList = serializers.deserialize(value,
               specifiedType: const FullType(List, const [
                 const FullType(Map,
                     const [const FullType(String), const FullType(dynamic)])
@@ -160,7 +170,9 @@ class _$SeatingConfigChange extends SeatingConfigChange {
   @override
   final String? objectIcon;
   @override
-  final List<Map<String, dynamic>>? maxSelectedObjects;
+  final int? maxSelectedObjects;
+  @override
+  final List<Map<String, dynamic>>? maxSelectedObjectList;
   @override
   final BuiltMap<String, String>? extraConfig;
   @override
@@ -179,6 +191,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
       this.objectLabel,
       this.objectIcon,
       this.maxSelectedObjects,
+      this.maxSelectedObjectList,
       this.extraConfig,
       this.availableCategories,
       this.unavailableCategories,
@@ -202,6 +215,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
         objectLabel == other.objectLabel &&
         objectIcon == other.objectIcon &&
         maxSelectedObjects == other.maxSelectedObjects &&
+        maxSelectedObjectList == other.maxSelectedObjectList &&
         extraConfig == other.extraConfig &&
         availableCategories == other.availableCategories &&
         unavailableCategories == other.unavailableCategories &&
@@ -215,6 +229,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
     _$hash = $jc(_$hash, objectLabel.hashCode);
     _$hash = $jc(_$hash, objectIcon.hashCode);
     _$hash = $jc(_$hash, maxSelectedObjects.hashCode);
+    _$hash = $jc(_$hash, maxSelectedObjectList.hashCode);
     _$hash = $jc(_$hash, extraConfig.hashCode);
     _$hash = $jc(_$hash, availableCategories.hashCode);
     _$hash = $jc(_$hash, unavailableCategories.hashCode);
@@ -230,6 +245,7 @@ class _$SeatingConfigChange extends SeatingConfigChange {
           ..add('objectLabel', objectLabel)
           ..add('objectIcon', objectIcon)
           ..add('maxSelectedObjects', maxSelectedObjects)
+          ..add('maxSelectedObjectList', maxSelectedObjectList)
           ..add('extraConfig', extraConfig)
           ..add('availableCategories', availableCategories)
           ..add('unavailableCategories', unavailableCategories)
@@ -254,11 +270,17 @@ class SeatingConfigChangeBuilder
   String? get objectIcon => _$this._objectIcon;
   set objectIcon(String? objectIcon) => _$this._objectIcon = objectIcon;
 
-  List<Map<String, dynamic>>? _maxSelectedObjects;
-  List<Map<String, dynamic>>? get maxSelectedObjects =>
-      _$this._maxSelectedObjects;
-  set maxSelectedObjects(List<Map<String, dynamic>>? maxSelectedObjects) =>
+  int? _maxSelectedObjects;
+  int? get maxSelectedObjects => _$this._maxSelectedObjects;
+  set maxSelectedObjects(int? maxSelectedObjects) =>
       _$this._maxSelectedObjects = maxSelectedObjects;
+
+  List<Map<String, dynamic>>? _maxSelectedObjectList;
+  List<Map<String, dynamic>>? get maxSelectedObjectList =>
+      _$this._maxSelectedObjectList;
+  set maxSelectedObjectList(
+          List<Map<String, dynamic>>? maxSelectedObjectList) =>
+      _$this._maxSelectedObjectList = maxSelectedObjectList;
 
   MapBuilder<String, String>? _extraConfig;
   MapBuilder<String, String> get extraConfig =>
@@ -293,6 +315,7 @@ class SeatingConfigChangeBuilder
       _objectLabel = $v.objectLabel;
       _objectIcon = $v.objectIcon;
       _maxSelectedObjects = $v.maxSelectedObjects;
+      _maxSelectedObjectList = $v.maxSelectedObjectList;
       _extraConfig = $v.extraConfig?.toBuilder();
       _availableCategories = $v.availableCategories?.toBuilder();
       _unavailableCategories = $v.unavailableCategories?.toBuilder();
@@ -325,6 +348,7 @@ class SeatingConfigChangeBuilder
               objectLabel: objectLabel,
               objectIcon: objectIcon,
               maxSelectedObjects: maxSelectedObjects,
+              maxSelectedObjectList: maxSelectedObjectList,
               extraConfig: _extraConfig?.build(),
               availableCategories: _availableCategories?.build(),
               unavailableCategories: _unavailableCategories?.build(),

--- a/lib/src/models/seatsio_serializers.g.dart
+++ b/lib/src/models/seatsio_serializers.g.dart
@@ -31,12 +31,6 @@ Serializers _$serializers = (new Serializers().toBuilder()
               BuiltMap, const [const FullType(String), const FullType(String)]),
           () => new MapBuilder<String, String>())
       ..addBuilderFactory(
-          const FullType(BuiltList, const [
-            const FullType(BuiltMap,
-                const [const FullType(String), const FullType(dynamic)])
-          ]),
-          () => new ListBuilder<BuiltMap<String, dynamic>>())
-      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())
       ..addBuilderFactory(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: seatsio
 description: Seatsio SDK for Flutter.
 repository: https://github.com/SongJiaqiang/seatsio-flutter
-version: 0.3.3
+version: 0.3.4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=2.17.0"
 
 dependencies:
   flutter:
@@ -23,9 +23,6 @@ dev_dependencies:
   build_runner: ^2.0.4
   built_value_generator: ^8.0.6
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
 flutter:
 
@@ -34,28 +31,3 @@ flutter:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
   #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
According to the official Seatsio [documentation](https://docs.seats.io/docs/renderer/config-maxselectedobjects/), `maxSelectedObjects` can be implemented in two ways: as a maximum total number of selected objects (by passing in a number), or you can set different limits for each category or ticket type, or even combination thereof (by passing in an object).

Last week, I merged a PR that changed the `maxSelectedObjects` type from `int` to `List<Map<String, dynamic>>`, causing users who originally used `maxSelectedObjects` to pass int values were unable to run it after upgrading.

Now, to support both types, I've added a new attribute.

``` dart
  int? get maxSelectedObjects;
  List<Map<String, dynamic>>? get maxSelectedObjectList;
```

``` dart
    if (maxSelectedObjectList != null) {
      configMap["maxSelectedObjects"] = maxSelectedObjectList;
    } else if (maxSelectedObjects != null) {
      configMap["maxSelectedObjects"] = maxSelectedObjects;
    }
```


